### PR TITLE
Fix crashes with unsupported tangent and symmetric constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slvsx"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "slvsx-core"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "slvsx-exporters"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "insta",


### PR DESCRIPTION
Fixes #21, #22, #23

## Problem
Using certain constraints in unsupported configurations caused assertion crashes:
- `tangent` constraint with `circle` entities → crash
- `symmetric` constraint in 3D mode → crash

## Solution
Added validation in `validator.rs` to catch these cases early with helpful error messages:

### Tangent with Circle
```
Error: Tangent constraint cannot be applied to entity 'circle1' (type: circle). 
Tangent constraints only work with arc, cubic, or line entities. 
Circles are not supported - use an Arc entity instead.
```

### Symmetric in 3D
```
Error: The 'symmetric' constraint (about line 'axis') is not supported in 3D mode. 
Use 'symmetric_horizontal' or 'symmetric_vertical' with a workplane instead. 
Example: {"type": "symmetric_horizontal", "a": "p1", "b": "p2", "workplane": "your_plane"}
```

## Documentation
Updated `docs/AI_MODELING_GUIDE.md` with new sections:
- Section 5: Tangent Constraints Don't Work with Circles
- Section 6: Symmetric Constraint Requires 2D Geometry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents crashes by validating unsupported constraint/entity combinations and documenting them.
> 
> - **Core**: Introduces `validate_constraint_entity_types` (invoked in `validate`) to reject `tangent` with `circle` entities and `symmetric` constraints in 3D, using an entity type map for precise errors
> - **Docs**: Expands `AI_MODELING_GUIDE.md` with sections on tangent vs circles and symmetric requiring 2D workplanes; renumbers related sections; clarifies solution vs input formats
> - **Versioning**: Bumps `slvsx`, `slvsx-core`, and `slvsx-exporters` to `0.2.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1df9f23f855ec5575aaa3f3d4b80c0189882f94f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->