### PR TITLE
Fix Handle isn't unique crash with many entities

### DIFF
--- a/examples/11_symmetric.json
+++ b/examples/11_symmetric.json
@@ -3,20 +3,10 @@
   "units": "mm",
   "entities": [
     {
-      "type": "point",
-      "id": "axis_top",
-      "at": [50, 100, 0]
-    },
-    {
-      "type": "point",
-      "id": "axis_bottom",
-      "at": [50, 0, 0]
-    },
-    {
-      "type": "line",
-      "id": "axis",
-      "p1": "axis_bottom",
-      "p2": "axis_top"
+      "type": "plane",
+      "id": "xy_plane",
+      "origin": [0, 0, 0],
+      "normal": [0, 0, 1]
     },
     {
       "type": "point",
@@ -71,28 +61,19 @@
   "constraints": [
     {
       "type": "fixed",
-      "entity": "axis_bottom"
+      "entity": "tip"
     },
     {
-      "type": "fixed",
-      "entity": "axis_top"
-    },
-    {
-      "type": "point_on_line",
-      "point": "tip",
-      "line": "axis"
-    },
-    {
-      "type": "symmetric",
+      "type": "symmetric_vertical",
       "a": "left_barb",
       "b": "right_barb",
-      "about": "axis"
+      "workplane": "xy_plane"
     },
     {
-      "type": "symmetric",
+      "type": "symmetric_vertical",
       "a": "left_base",
       "b": "right_base",
-      "about": "axis"
+      "workplane": "xy_plane"
     },
     {
       "type": "distance",

--- a/examples/outputs/11_symmetric.svg
+++ b/examples/outputs/11_symmetric.svg
@@ -1,14 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="8.1 -22.3 81.9 143.8" width="800" height="800">
-  <circle id="axis_top" cx="50.000000" cy="100.000000" r="2" fill="black"/>
-  <circle id="tip" cx="50.000000" cy="101.425692" r="2" fill="black"/>
-  <circle id="left_barb" cx="28.128644" cy="80.891725" r="2" fill="black"/>
-  <circle id="right_base" cx="55.000000" cy="0.000000" r="2" fill="black"/>
-  <line id="axis" x1="50.000000" y1="0.000000" x2="50.000000" y2="100.000000" stroke="black"/>
-  <line id="right_side" x1="50.000000" y1="101.425692" x2="70.000000" y2="80.000000" stroke="black"/>
-  <line id="left_shaft" x1="28.128644" y1="80.891725" x2="45.436172" y2="-2.327560" stroke="black"/>
-  <line id="left_side" x1="50.000000" y1="101.425692" x2="28.128644" y2="80.891725" stroke="black"/>
-  <circle id="right_barb" cx="70.000000" cy="80.000000" r="2" fill="black"/>
-  <circle id="left_base" cx="45.436172" cy="-2.327560" r="2" fill="black"/>
-  <circle id="axis_bottom" cx="50.000000" cy="0.000000" r="2" fill="black"/>
-  <line id="right_shaft" x1="70.000000" y1="80.000000" x2="55.000000" y2="0.000000" stroke="black"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="18.0 -27.2 69.6 147.2" width="800" height="800">
+  <circle id="left_barb" cx="38.040716" cy="72.486812" r="2" fill="black"/>
+  <circle id="left_base" cx="67.665788" cy="-7.183478" r="2" fill="black"/>
+  <line id="left_shaft" x1="38.040716" y1="72.486812" x2="67.665788" y2="-7.183478" stroke="black"/>
+  <line id="left_side" x1="50.000000" y1="100.000000" x2="38.040716" y2="72.486812" stroke="black"/>
+  <circle id="right_barb" cx="52.131519" cy="-6.164315" r="2" fill="black"/>
+  <circle id="right_base" cx="52.254975" cy="78.835595" r="2" fill="black"/>
+  <line id="right_shaft" x1="52.131519" y1="-6.164315" x2="52.254975" y2="78.835595" stroke="black"/>
+  <line id="right_side" x1="50.000000" y1="100.000000" x2="52.131519" y2="-6.164315" stroke="black"/>
+  <circle id="tip" cx="50.000000" cy="100.000000" r="2" fill="black"/>
 </svg>


### PR DESCRIPTION
Fixes #25

## Problem
The CLI crashed with `Assertion failed: Handle isn't unique` when processing JSON files with many entities (30+ point2_d/line2_d entities).

## Root Cause
Internal entity IDs for circles, arcs, and workplanes were using small offsets:
- Circle normals: `3000 + id`
- Circle origins: `6000 + id`
- Workplanes: `5000 + id`
- etc.

When a user created entity ID 2001 (mapped to `1000 + 2001 = 3001`), it collided with circle normal ID (`3000 + 1 = 3001`).

## Solution
Changed to use much larger offsets that won't collide:
- Circle normals: `100000 + id`
- Circle origins: `200000 + id`
- Circle workplanes: `300000 + id`
- Circle 2D centers: `400000 + id`
- Circle distances: `500000 + id`
- Circle entities: `600000 + id`
- Arc normals: `700000 + id`
- Workplane normals: `800000 + id`

This allows up to 100,000 user entities without ID collisions.

## Other Changes
Updated `examples/11_symmetric.json` to use `symmetric_vertical` with a workplane (required since `symmetric` about a line doesn't work in 3D - see PR #24).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses handle collisions by remapping internal IDs to large, non-overlapping ranges.
> 
> - Move circle internals to high offsets: `Normal 100000+`, `Origin 200000+`, `Workplane 300000+`, `2D Center 400000+`, `Distance 500000+`, `Circle 600000+`; add `Arc normals 700000+`, `Workplane normals 800000+`
> - Update functions to use new mappings: `real_slvs_add_circle`, `real_slvs_add_arc`, `real_slvs_add_workplane`, and constraints referencing circles (`equal_radius`, `point_on_circle`, `diameter`); adjust `real_slvs_get_circle_position` to read new IDs
> - Refresh `examples/11_symmetric.json` to define `xy_plane`, fix `tip`, and use `symmetric_vertical` with a workplane; regenerate corresponding SVG output
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e66dcb696247fac4324312be53c230002fb4787c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->