### PR TITLE
ci: auto-publish to npm on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,3 +333,30 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-npm:
+    name: Publish to npm
+    needs: [release]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs index
+        run: npm run build:docs
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds automatic npm publishing to the release workflow.

## Setup Required
1. Create an npm **Automation** token at https://www.npmjs.com/settings/tokens
2. Add it as a GitHub secret named `NPM_TOKEN`

## What it does
- After the GitHub release is created, publishes the package to npm
- Builds the docs index before publishing
- Uses `--access public` for the scoped package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automates npm publishing as part of the release pipeline.
> 
> - Adds `publish-npm` job (needs `release`) triggered on tags or `workflow_dispatch`
> - Sets up Node.js 20 with npm registry, runs `npm ci`, builds docs via `npm run build:docs`
> - Publishes package with `npm publish --access public` using `NODE_AUTH_TOKEN` (`NPM_TOKEN` secret)
> - Minor workflow tidy (ensures `GITHUB_TOKEN` is set in `release` job)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfce4debd79f1b6c6e8466c293d9f1c6de10a206. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->