### PR TITLE
Add workplane support to equal_length and improve InvalidSystem error

### DIFF
--- a/crates/core/src/ffi.rs
+++ b/crates/core/src/ffi.rs
@@ -189,6 +189,7 @@ extern "C" {
         id: c_int,
         line1_id: c_int,
         line2_id: c_int,
+        workplane_id: c_int,
     ) -> c_int;
     pub fn real_slvs_add_equal_radius_constraint(
         sys: *mut SolverSystem,
@@ -743,9 +744,10 @@ impl Solver {
         id: i32,
         line1_id: i32,
         line2_id: i32,
+        workplane_id: i32,
     ) -> Result<(), FfiError> {
         unsafe {
-            let result = real_slvs_add_equal_length_constraint(self.system, id, line1_id, line2_id);
+            let result = real_slvs_add_equal_length_constraint(self.system, id, line1_id, line2_id, workplane_id);
             if result == 0 {
                 Ok(())
             } else {
@@ -1552,8 +1554,8 @@ mod tests {
         solver.add_fixed_constraint(100, 1, 0).unwrap();
         solver.add_fixed_constraint(101, 3, 0).unwrap();
 
-        // Add equal length constraint
-        let result = solver.add_equal_length_constraint(102, 10, 11);
+        // Add equal length constraint (0 = 3D / FREE_IN_3D)
+        let result = solver.add_equal_length_constraint(102, 10, 11, 0);
         assert!(result.is_ok(), "Should be able to add equal length constraint via FFI");
 
         // Solve - should succeed

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -245,6 +245,9 @@ pub enum Constraint {
     },
     EqualLength {
         entities: Vec<String>,
+        /// Workplane for 2D lines (required for Line2D, omit for 3D Line)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        workplane: Option<String>,
     },
     EqualRadius {
         a: String,

--- a/crates/core/src/translator.rs
+++ b/crates/core/src/translator.rs
@@ -66,7 +66,7 @@ impl Translator {
             | Constraint::Tangent { a, b }
             | Constraint::SameOrientation { a, b }
             | Constraint::CubicLineTangent { cubic: a, line: b } => vec![a.clone(), b.clone()],
-            Constraint::Parallel { entities } | Constraint::EqualLength { entities } => entities.clone(),
+            Constraint::Parallel { entities } | Constraint::EqualLength { entities, .. } => entities.clone(),
             Constraint::EqualAngle { lines } => lines.clone(),
             Constraint::Horizontal { a, workplane } | Constraint::Vertical { a, workplane } => {
                 vec![a.clone(), workplane.clone()]
@@ -286,6 +286,7 @@ mod tests {
             Constraint::Vertical { a: "l1".to_string(), workplane: "wp1".to_string() },
             Constraint::EqualLength {
                 entities: vec!["l1".to_string(), "l2".to_string()],
+                workplane: None,
             },
             Constraint::EqualRadius {
                 a: "c1".to_string(),

--- a/crates/core/src/validator.rs
+++ b/crates/core/src/validator.rs
@@ -70,7 +70,7 @@ impl Validator {
                 Constraint::SameOrientation { a, b } | Constraint::CubicLineTangent { cubic: a, line: b } => {
                     vec![a.as_str(), b.as_str()]
                 }
-                Constraint::Parallel { entities } | Constraint::EqualLength { entities } => {
+                Constraint::Parallel { entities } | Constraint::EqualLength { entities, .. } => {
                     entities.iter().map(|s| s.as_str()).collect()
                 }
                 Constraint::EqualAngle { lines } => {
@@ -1204,6 +1204,7 @@ mod tests {
                 },
                 Constraint::EqualLength {
                     entities: vec!["l1".to_string(), "l2".to_string()],
+                    workplane: None,
                 },
                 Constraint::Horizontal {
                     a: "l1".to_string(),

--- a/crates/core/tests/constraint_effectiveness_tests.rs
+++ b/crates/core/tests/constraint_effectiveness_tests.rs
@@ -369,6 +369,7 @@ fn test_equal_length_constraint_changes_solution() {
     let mut constraints_with = base_constraints.clone();
     constraints_with.push(Constraint::EqualLength {
         entities: vec!["l1".to_string(), "l2".to_string()],
+        workplane: None,
     });
     let doc_with = create_test_doc(base_entities.clone(), constraints_with);
     let result_with = solve_and_get(&doc_with).expect("Should solve");

--- a/crates/core/tests/ffi_error_tests.rs
+++ b/crates/core/tests/ffi_error_tests.rs
@@ -29,6 +29,7 @@ fn test_error_mapping_with_iterations(ffi_error: FfiError, expected_error: Error
         (Error::Ffi(a), Error::Ffi(b)) => {
             assert_eq!(a, b);
         }
+        (Error::InvalidSystem, Error::InvalidSystem) => {}
         _ => panic!("Error types don't match: {:?} vs {:?}", mapped, expected_error),
     }
 }
@@ -67,7 +68,7 @@ fn test_ffi_error_mapping_too_many_unknowns() {
 fn test_ffi_error_mapping_invalid_system() {
     test_error_mapping(
         FfiError::InvalidSystem,
-        Error::Ffi("Invalid solver system".to_string()),
+        Error::InvalidSystem,
     );
 }
 

--- a/docs/AI_MODELING_GUIDE.md
+++ b/docs/AI_MODELING_GUIDE.md
@@ -57,8 +57,8 @@ Different constraints use different field names. Check the schema carefully:
 | `equal_radius` | `a: circle/arc`, `b: circle/arc` |
 | `diameter` | `circle: circle_id`, `value` |
 | `symmetric` | `a: point`, `b: point`, `about: line` (**NOT supported in 3D!**) |
-| `symmetric_horizontal` | `a: point`, `b: point`, `workplane: plane` |
-| `symmetric_vertical` | `a: point`, `b: point`, `workplane: plane` |
+| `symmetric_horizontal` | `a: point`, `b: point`, `workplane: plane` — **Y1=Y2, X1=-X2** (mirror across Y-axis) |
+| `symmetric_vertical` | `a: point`, `b: point`, `workplane: plane` — **X1=X2, Y1=-Y2** (mirror across X-axis) |
 | `dragged` | `point`, `workplane` (optional) - locks point position |
 
 ## 2D Geometry Setup (Required for horizontal/vertical/symmetric)

--- a/ffi/real_slvs_wrapper.c
+++ b/ffi/real_slvs_wrapper.c
@@ -515,20 +515,22 @@ int real_slvs_add_vertical_constraint(RealSlvsSystem* s, int id, int line_id, in
 }
 
 // Add equal length constraint (between two lines)
-int real_slvs_add_equal_length_constraint(RealSlvsSystem* s, int id, int line1_id, int line2_id) {
+// For 2D lines, pass the workplane_id; for 3D lines, pass 0
+int real_slvs_add_equal_length_constraint(RealSlvsSystem* s, int id, int line1_id, int line2_id, int workplane_id) {
     if (!s) return -1;
-    
+
     Slvs_hGroup g = 1;
-    
+
     // Use proper ID mapping for constraint and entities
     Slvs_hConstraint constraint_id = 10000 + id;
     Slvs_hEntity line1 = 1000 + line1_id;
     Slvs_hEntity line2 = 1000 + line2_id;
-    
+    Slvs_hEntity workplane = (workplane_id > 0) ? (1000 + workplane_id) : SLVS_FREE_IN_3D;
+
     s->sys.constraint[s->sys.constraints++] = Slvs_MakeConstraint(
-        constraint_id, g, SLVS_C_EQUAL_LENGTH_LINES, SLVS_FREE_IN_3D,
+        constraint_id, g, SLVS_C_EQUAL_LENGTH_LINES, workplane,
         0, 0, 0, line1, line2);
-    
+
     return 0;
 }
 

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -670,8 +670,8 @@ All constraints with their field names:
 | \`tangent\` | \`a\`, \`b\` | Make arc/line tangent (NOT for circles!) |
 | \`diameter\` | \`circle\`, \`value\` | Set circle diameter |
 | \`symmetric\` | \`a\`, \`b\`, \`about\` | Mirror symmetry (2D only!) |
-| \`symmetric_horizontal\` | \`a\`, \`b\`, \`workplane\` | Horizontal mirror symmetry |
-| \`symmetric_vertical\` | \`a\`, \`b\`, \`workplane\` | Vertical mirror symmetry |
+| \`symmetric_horizontal\` | \`a\`, \`b\`, \`workplane\` | Same Y, opposite X (mirror across Y-axis) |
+| \`symmetric_vertical\` | \`a\`, \`b\`, \`workplane\` | Same X, opposite Y (mirror across X-axis) |
 | \`dragged\` | \`point\`, \`workplane?\` | Lock point position absolutely |
 
 ## Important Notes


### PR DESCRIPTION
## Summary
- Add optional `workplane` parameter to `equal_length` constraint for 2D lines
- Add dedicated `InvalidSystem` error type with helpful diagnostic message explaining common causes
- Update documentation for `symmetric_horizontal`/`symmetric_vertical` constraints

## Changes

### equal_length constraint
The `equal_length` constraint now accepts an optional `workplane` field for 2D lines:
```json
{"type": "equal_length", "entities": ["line1", "line2"], "workplane": "xy_plane"}
```

### Improved error message
The new `InvalidSystem` error provides actionable guidance:
```
Error: Invalid solver system: constraint matrix is singular. This typically means:
  - Redundant constraints (e.g., distance constraints on both lines + equal_length)
  - Conflicting 2D/3D constraint workplanes
  - Identical constraints applied multiple times
Tip: Use distance on ONE entity + equal_length, not distance on BOTH + equal_length
```

### Documentation updates
Clarified SolveSpace's counterintuitive naming for symmetric constraints:
- `symmetric_horizontal`: Y1=Y2, X1=-X2 (mirror across Y-axis)
- `symmetric_vertical`: X1=X2, Y1=-Y2 (mirror across X-axis)

## Test plan
- [x] All existing tests pass
- [x] New error type has proper exit code (7)
- [x] FFI tests updated for new `add_equal_length_constraint` signature

Closes #49, #51, #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces 2D workplane awareness for equal-length constraints and surfaces a dedicated solver error for singular systems.
> 
> - Adds optional `workplane` to `Constraint::EqualLength`; propagates through `constraint_registry`, `translator`, and `validator`
> - Updates FFI and C wrapper: `add_equal_length_constraint` now takes `workplane_id`; call sites and tests adjusted
> - Maps `FfiError::InvalidSystem` to new `Error::InvalidSystem` with detailed message and exit code `7`; updates tests
> - Documentation/help text refined for `symmetric_horizontal`/`symmetric_vertical` semantics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3be3321014cbfdc63b07b27b4b301f36e1ec303. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->